### PR TITLE
Fix design for the date-picker arrow

### DIFF
--- a/app/assets/stylesheets/react-datepicker.css
+++ b/app/assets/stylesheets/react-datepicker.css
@@ -179,6 +179,8 @@
   position: absolute;
   top: 10px;
   width: 0;
+  height: 0;
+  overflow: hidden;
   padding: 0;
   border: 0.45rem solid transparent;
   z-index: 1;


### PR DESCRIPTION
<img width="283" alt="2018-09-13 14 15 15" src="https://user-images.githubusercontent.com/1570530/45468922-27f75a00-b762-11e8-855e-5866750783ae.png">

it occurs when react-datepicker v1.5.0 -> v1.6.0

https://github.com/Hacker0x01/react-datepicker/compare/v1.6.0...master