### PR TITLE
Bundle update on 2018-10-25

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/thoughtbot/shoulda-matchers.git
-  revision: a465e796e88c8e73be67b9b739473e67707674ef
+  revision: 94b28e4ef4cc001b1c0b4386143b8c05ac163550
   specs:
-    shoulda-matchers (3.1.2)
+    shoulda-matchers (4.0.0.rc1)
       activesupport (>= 4.2.0)
 
 GEM
@@ -64,7 +64,7 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.1.4)
+    autoprefixer-rails (9.3.1)
       execjs
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -84,17 +84,18 @@ GEM
       sass (>= 3.5.2)
     builder (3.2.3)
     byebug (10.0.2)
-    capybara (3.8.2)
+    capybara (3.10.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
-      xpath (~> 3.1)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
     capybara-email (3.0.1)
       capybara (>= 2.4, < 4.0)
       mail
-    capybara-screenshot (1.0.21)
+    capybara-screenshot (1.0.22)
       capybara (>= 1.0, < 4)
       launchy
     case_transform (0.2)
@@ -104,7 +105,7 @@ GEM
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
-    codecov (0.1.10)
+    codecov (0.1.13)
       json
       simplecov
       url
@@ -152,7 +153,7 @@ GEM
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashie (3.5.7)
-    i18n (1.1.0)
+    i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
     jaro_winkler (1.5.1)
@@ -184,7 +185,7 @@ GEM
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
@@ -195,7 +196,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     nio4r (2.3.1)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     oauth (0.5.4)
     omniauth (1.8.1)
@@ -264,6 +265,7 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
+    regexp_parser (1.2.0)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (2.4.0)
@@ -275,13 +277,13 @@ GEM
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.1)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-rails (3.8.0)
+    rspec-rails (3.8.1)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
@@ -319,22 +321,22 @@ GEM
     scss_lint (0.57.1)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
-    selenium-webdriver (3.14.0)
+    selenium-webdriver (3.14.1)
       childprocess (~> 0.5)
-      rubyzip (~> 1.2)
+      rubyzip (~> 1.2, >= 1.2.2)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     slack-notifier (2.3.2)
-    slim (3.0.9)
+    slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
-      tilt (>= 1.3.3, < 2.1)
-    slim-rails (3.1.3)
+      tilt (>= 2.0.6, < 2.1)
+    slim-rails (3.2.0)
       actionpack (>= 3.1)
       railties (>= 3.1)
-      slim (~> 3.0)
+      slim (>= 3.0, < 5.0)
     slim_lint (0.16.1)
       rake (>= 10, < 13)
       rubocop (>= 0.50.0)
@@ -380,7 +382,7 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (3.1.0)
+    xpath (3.2.0)
       nokogiri (~> 1.8)
 
 PLATFORMS


### PR DESCRIPTION
```
Using i18n 1.1.1 (was 1.1.0)
Using nokogiri 1.8.5 (was 1.8.4)
Fetching autoprefixer-rails 9.3.1 (was 9.1.4)
Installing autoprefixer-rails 9.3.1 (was 9.1.4)
Fetching regexp_parser 1.2.0
Installing regexp_parser 1.2.0
Fetching xpath 3.2.0 (was 3.1.0)
Installing xpath 3.2.0 (was 3.1.0)
Fetching capybara 3.10.0 (was 3.8.2)
Installing capybara 3.10.0 (was 3.8.2)
Fetching capybara-screenshot 1.0.22 (was 1.0.21)
Installing capybara-screenshot 1.0.22 (was 1.0.21)
Fetching codecov 0.1.13 (was 0.1.10)
Installing codecov 0.1.13 (was 0.1.10)
Fetching rspec-expectations 3.8.2 (was 3.8.1)
Installing rspec-expectations 3.8.2 (was 3.8.1)
Fetching rspec-rails 3.8.1 (was 3.8.0)
Installing rspec-rails 3.8.1 (was 3.8.0)
Fetching selenium-webdriver 3.14.1 (was 3.14.0)
Installing selenium-webdriver 3.14.1 (was 3.14.0)
Using shoulda-matchers 4.0.0.rc1 (was 3.1.2) from https://github.com/thoughtbot/shoulda-matchers.git (at master@94b28e4)
Fetching slim 4.0.1 (was 3.0.9)
Installing slim 4.0.1 (was 3.0.9)
Fetching slim-rails 3.2.0 (was 3.1.3)
Installing slim-rails 3.2.0 (was 3.1.3)
```