### PR TITLE
Revert "Bump typescript from 4.1.5 to 4.2.2 in /client"

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -47,7 +47,7 @@
     "redux-thunk": "^2.3.0",
     "serve": "^11.3.1",
     "sortablejs": "^1.13.0",
-    "typescript": "~4.2.2"
+    "typescript": "~4.1.5"
   },
   "scripts": {
     "eslint": "eslint 'src/**/**.tsx' 'src/**/**.ts'",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -13606,10 +13606,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
-  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
+typescript@~4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
+  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Reverts summer-snowflake/pig-book#634

4.1.5に固定したのを忘れてた